### PR TITLE
Paths instead of str

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -262,18 +262,18 @@ pub fn initialize_chunk_data(
         let (terrain_config, terrain_data) = terrain_query.get(terrain_entity_id).unwrap();
 
         let chunk_id = chunk.chunk_id;
-
+        let file_name = format!("{}.png", chunk_id);
         //default_terrain/diffuse
-        let height_texture_folder_path = &terrain_config.height_folder_path;
-        let height_texture_path = format!("{}/{}.png", height_texture_folder_path, chunk_id);
-        println!("loading from {}", height_texture_path);
+        let height_texture_path = terrain_config.height_folder_path.with_file_name(file_name);
+        println!("loading from {}", height_texture_path.display());
 
         let height_map_image_handle: Handle<Image> = asset_server.load(height_texture_path);
 
         //default_terrain/splat
         let splat_texture_folder_path = &terrain_config.splat_folder_path;
-        let splat_texture_path = format!("{}/{}.png", splat_texture_folder_path, chunk_id);
-        println!("loading from {}", splat_texture_path);
+
+        let splat_texture_path = terrain_config.splat_folder_path.with_file_name(file_name);
+        println!("loading from {}", splat_texture_path.display());
 
         let splat_image_handle: Handle<Image> = asset_server.load(splat_texture_path);
 

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -263,16 +263,15 @@ pub fn initialize_chunk_data(
 
         let chunk_id = chunk.chunk_id;
         let file_name = format!("{}.png", chunk_id);
+
         //default_terrain/diffuse
-        let height_texture_path = terrain_config.height_folder_path.with_file_name(file_name);
+        let height_texture_path = terrain_config.height_folder_path.join(&file_name);
         println!("loading from {}", height_texture_path.display());
 
         let height_map_image_handle: Handle<Image> = asset_server.load(height_texture_path);
 
         //default_terrain/splat
-        let splat_texture_folder_path = &terrain_config.splat_folder_path;
-
-        let splat_texture_path = terrain_config.splat_folder_path.with_file_name(file_name);
+        let splat_texture_path = terrain_config.splat_folder_path.join(&file_name);
         println!("loading from {}", splat_texture_path.display());
 
         let splat_image_handle: Handle<Image> = asset_server.load(splat_texture_path);
@@ -910,7 +909,7 @@ where
             .expect("Failed to create image buffer");
 
         // Save the image to the specified file path
-        img.save(save_file_path).expect("Failed to save splat map");
+        img.save(&save_file_path).expect("Failed to save splat map");
         println!("saved splat image {}", save_file_path.as_ref().display());
     } else {
         eprintln!("Unsupported image format for saving: {:?}", format);

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -888,7 +888,10 @@ pub fn save_chunk_height_map_to_disk<P>(
         .expect("Failed to write PNG data");
 }
 
-pub fn save_chunk_splat_map_to_disk(splat_image: &Image, save_file_path: String) {
+pub fn save_chunk_splat_map_to_disk<P>(splat_image: &Image, save_file_path: P)
+where
+    P: AsRef<Path> + Clone,
+{
     // Attempt to find the image in the Assets<Image> collection
 
     // Assuming the image format is Rgba8, which is common for splat maps
@@ -907,18 +910,17 @@ pub fn save_chunk_splat_map_to_disk(splat_image: &Image, save_file_path: String)
             .expect("Failed to create image buffer");
 
         // Save the image to the specified file path
-        img.save(&save_file_path).expect("Failed to save splat map");
-
-        println!("saved splat image {:?}", save_file_path.clone());
+        img.save(save_file_path).expect("Failed to save splat map");
+        println!("saved splat image {}", save_file_path.as_ref().display());
     } else {
         eprintln!("Unsupported image format for saving: {:?}", format);
     }
 }
 
-pub fn save_chunk_collision_data_to_disk(
-    serialized_collision_data: Vec<u8>,
-    save_file_path: String,
-) {
+pub fn save_chunk_collision_data_to_disk<P>(serialized_collision_data: Vec<u8>, save_file_path: P)
+where
+    P: AsRef<Path>,
+{
     match fs::write(save_file_path, serialized_collision_data) {
         Ok(_) => println!("Successfully saved collision data to file."),
         Err(e) => println!("Failed to save to file: {}", e),

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -852,10 +852,12 @@ pub fn update_chunk_visibility(
 }
 
 // outputs as R16 grayscale
-pub fn save_chunk_height_map_to_disk(
+pub fn save_chunk_height_map_to_disk<P>(
     chunk_height_data: &SubHeightMapU16, // Adjusted for direct Vec<Vec<u16>> input
-    save_file_path: String,
-) {
+    save_file_path: P,
+) where
+    P: AsRef<Path>,
+{
     let chunk_height_data = chunk_height_data.0.clone();
 
     // Assuming chunk_height_data is a Vec<Vec<u16>>
@@ -863,8 +865,7 @@ pub fn save_chunk_height_map_to_disk(
     let width = chunk_height_data.first().map_or(0, |row| row.len());
 
     // Prepare the file and writer
-    let path = Path::new(&save_file_path);
-    let file = File::create(path).expect("Failed to create file");
+    let file = File::create(save_file_path).expect("Failed to create file");
     let ref mut w = BufWriter::new(file);
 
     // Set up the encoder. Since PNG is the format that supports 16-bit grayscale natively, we use it here.

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,4 +1,5 @@
 use std::ops::{Add, Div, Neg};
+use std::path::PathBuf;
 
 use bevy::ecs::entity::Entity;
 use bevy::math::Vec2;
@@ -118,16 +119,17 @@ pub fn apply_command_events(
 
             match ev {
                 TerrainCommandEvent::SaveAllChunks(save_height, save_splat, save_collision) => {
+                    let file_name = format!("{}.png", chunk.chunk_id);
+                    let asset_folder_path = PathBuf::from("assets");
                     if *save_height {
                         if let Some(chunk_height_data) =
                             chunk_height_maps.chunk_height_maps.get(&chunk.chunk_id)
                         {
                             save_chunk_height_map_to_disk(
                                 chunk_height_data,
-                                format!(
-                                    "assets/{}/{}.png",
-                                    terrain_config.height_folder_path, chunk.chunk_id
-                                ),
+                                asset_folder_path
+                                    .join(&terrain_config.height_folder_path)
+                                    .join(&file_name),
                             );
                         }
                     }
@@ -137,10 +139,9 @@ pub fn apply_command_events(
                             if let Some(splat_image) = images.get(splat_image_handle) {
                                 save_chunk_splat_map_to_disk(
                                     splat_image,
-                                    format!(
-                                        "assets/{}/{}.png",
-                                        terrain_config.splat_folder_path, chunk.chunk_id
-                                    ),
+                                    asset_folder_path
+                                        .join(&terrain_config.splat_folder_path)
+                                        .join(&file_name),
                                 );
                             }
                         }
@@ -212,13 +213,12 @@ pub fn apply_command_events(
 
                                 let collider_data_serialized =
                                     bincode::serialize(&collider).unwrap();
-
+                                let file_name = format!("{}.col", chunk.chunk_id);
                                 save_chunk_collision_data_to_disk(
                                     collider_data_serialized,
-                                    format!(
-                                        "assets/{}/{}.col",
-                                        terrain_config.collider_data_folder_path, chunk.chunk_id
-                                    ),
+                                    asset_folder_path
+                                        .join(&terrain_config.collider_data_folder_path)
+                                        .join(file_name),
                                 );
                                 continue;
                             }

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -1,4 +1,4 @@
-use bevy::asset::LoadState;
+use bevy::asset::{AssetPath, LoadState};
 use bevy::prelude::*;
 use bevy::render::render_resource::{
     AddressMode, FilterMode, SamplerDescriptor, TextureDescriptor, TextureFormat,
@@ -135,7 +135,7 @@ pub fn load_terrain_texture_from_image(
         if terrain_data.texture_image_handle.is_none() {
             let array_texture_path = &terrain_config.diffuse_folder_path;
 
-            let tex_image = asset_server.load(array_texture_path);
+            let tex_image = asset_server.load(AssetPath::from_path(array_texture_path));
             terrain_data.texture_image_handle = Some(tex_image);
         }
 

--- a/src/terrain_config.rs
+++ b/src/terrain_config.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use std::fs::File;
 use std::io::Read;
+use std::path::PathBuf;
 
 #[derive(Component, Deserialize, Serialize, Clone)]
 pub struct TerrainConfig {
@@ -29,10 +30,10 @@ pub struct TerrainConfig {
     pub use_greedy_mesh: bool,
 
     pub texture_image_sections: u32,
-    pub diffuse_folder_path: String,
-    pub height_folder_path: String,
-    pub splat_folder_path: String,
-    pub collider_data_folder_path: String,
+    pub diffuse_folder_path: PathBuf,
+    pub height_folder_path: PathBuf,
+    pub splat_folder_path: PathBuf,
+    pub collider_data_folder_path: PathBuf,
 }
 
 impl Default for TerrainConfig {

--- a/src/terrain_config.rs
+++ b/src/terrain_config.rs
@@ -52,10 +52,10 @@ impl Default for TerrainConfig {
             use_greedy_mesh: false,
             texture_image_sections: 8,
 
-            diffuse_folder_path: "diffuse".into(),
-            height_folder_path: "height".into(),
-            splat_folder_path: "splat".into(),
-            collider_data_folder_path: "collider".into(),
+            diffuse_folder_path: "diffuse/".into(),
+            height_folder_path: "height/".into(),
+            splat_folder_path: "splat/".into(),
+            collider_data_folder_path: "collider/".into(),
         }
     }
 }


### PR DESCRIPTION
Strings as paths is not great if you're targeting multiple OSes. Better use `Path`.
Since `&str` implements `AsRef<Path>` this shouldn't reduce useability